### PR TITLE
fix unable to import package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "enrich-email",
   "version": "1.0.0",
-  "main": "dist/node/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "license": "MIT",
   "author": "Tait Brown <taitbrown@gmail.com>",


### PR DESCRIPTION
Getting the following error when attempting to import the `enrich-email` package:
```
node:internal/modules/esm/resolve:188
  const resolvedOption = FSLegacyMainResolve(packageJsonUrlString, packageConfig.main, baseStringified);
                         ^

Error: Cannot find package '/Users/davidgomes/repos/email-test/node_modules/enrich-email/package.json' imported from /Users/davidgomes/repos/email-test/index.js
    at legacyMainResolve (node:internal/modules/esm/resolve:188:26)
    at packageResolve (node:internal/modules/esm/resolve:767:14)
    at moduleResolve (node:internal/modules/esm/resolve:829:20)
    at defaultResolve (node:internal/modules/esm/resolve:1034:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:375:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:344:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:220:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v20.6.1
```

On closer look, it seems that the `dist` folder has no `node` subfolder. Updating package.json to reflect the lack of a node folder resolved the above error.